### PR TITLE
rancheros-install: do not use tty mode for rancher/os containers

### DIFF
--- a/src/docker/02-console/rancheros-install
+++ b/src/docker/02-console/rancheros-install
@@ -86,10 +86,10 @@ if [ "${FORCE_INSTALL}" != "true" ] && [ "${INSTALL_TYPE}" != "rancher-upgrade" 
 fi
 
 if [ "$PARTITION_FLAG" == "true" ]; then
-    system-docker run --net=host -it --privileged --entrypoint=/scripts/set-disk-partitions --volumes-from=all-volumes ${INSTALL_CONTAINER_IMAGE}:${INSTALLER_VERSION} ${DEVICE}
+    system-docker run --net=host --privileged --entrypoint=/scripts/set-disk-partitions --volumes-from=all-volumes ${INSTALL_CONTAINER_IMAGE}:${INSTALLER_VERSION} ${DEVICE}
     system-docker start udev
 fi
 
-system-docker run --volumes-from=user-volumes --net=host -it --privileged ${INSTALL_CONTAINER_IMAGE}:${INSTALLER_VERSION} -d ${DEVICE} -t ${INSTALL_TYPE} ${EXTRA_ARGS}
+system-docker run --volumes-from=user-volumes --net=host --privileged ${INSTALL_CONTAINER_IMAGE}:${INSTALLER_VERSION} -d ${DEVICE} -t ${INSTALL_TYPE} ${EXTRA_ARGS}
 
 echo "RancherOS has been installed. Please reboot..."


### PR DESCRIPTION
rancheros-install: do not use tty mode running rancher/os containers

as it is not necessary. Also, when rancheros-install is called non-interactively,
docker complains: cannot enable tty mode on non tty input
