### PR TITLE
fix ntp service

### DIFF
--- a/src/docker/02-ntp/ntp.sh
+++ b/src/docker/02-ntp/ntp.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec ntpd
+exec ntpd --nofork


### PR DESCRIPTION
fix: `ntpd`'s default behaviour is to fork a process and quit.

To run it in a container, we want it not to fork and just run
as one process. 
