### PR TITLE
fix /etc/lsb-release

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -8,7 +8,7 @@ DO_PUSH="$1"
 cd $(dirname $0)
 
 source ./version
-VERSION=${VERSION:?"VERSION not set"}
+export VERSION=${VERSION:?"VERSION not set"}
 
 cd ${BASEDIR}
 

--- a/src/docker/02-console/.prebuild.sh
+++ b/src/docker/02-console/.prebuild.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+VERSION=${VERSION:?"VERSION not set"}
+
+cd $(dirname $0)
+
+rm -rf ./build
+mkdir -p ./build
+
+cat > ./build/lsb-release << EOF
+DISTRIB_ID=RancherOS
+DISTRIB_RELEASE=${VERSION}
+DISTRIB_DESCRIPTION="RancherOS ${VERSION}"
+EOF

--- a/src/docker/02-console/Dockerfile
+++ b/src/docker/02-console/Dockerfile
@@ -1,8 +1,6 @@
 FROM rancher/os-base
-COPY console.sh /usr/sbin/
-COPY docker-init /usr/sbin/
-COPY update-ssh-keys /usr/bin/
-COPY rancheros-install /usr/sbin/
+COPY console.sh docker-init update-ssh-keys rancheros-install /usr/sbin/
+COPY build/lsb-release /etc/
 RUN sed -i 's/rancher:!/rancher:*/g' /etc/shadow && \
     sed -i 's/docker:!/docker:*/g' /etc/shadow && \
     sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 180/g' /etc/ssh/sshd_config && \

--- a/src/docker/02-console/console.sh
+++ b/src/docker/02-console/console.sh
@@ -63,13 +63,6 @@ fi
 
 setup_ssh
 
-VERSION="$(ros -v | awk '{print $NF}')"
-cat > /etc/lsb-release << EOF
-DISTRIB_ID=RancherOS
-DISTRIB_RELEASE=${VERSION}
-DISTRIB_DESCRIPTION="RancherOS ${VERSION}"
-EOF
-
 cat > /etc/respawn.conf << EOF
 /sbin/getty 115200 tty1
 /sbin/getty 115200 tty2
@@ -92,6 +85,7 @@ if ! grep -q '^AllowGroups docker' /etc/ssh/sshd_config; then
     echo "AllowGroups docker" >> /etc/ssh/sshd_config
 fi
 
+VERSION="$(ros os version)"
 ID_TYPE="busybox"
 if [ -e /etc/os-release ] && grep -q 'ID_LIKE=' /etc/os-release; then
     ID_TYPE=$(grep 'ID_LIKE=' /etc/os-release | cut -d'=' -f2)

--- a/src/docker/10-debianconsole/Dockerfile
+++ b/src/docker/10-debianconsole/Dockerfile
@@ -3,11 +3,7 @@ RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates
 RUN rm -rf /etc/ssh/*key*
-COPY build/entry.sh /usr/sbin/
-COPY build/console.sh /usr/sbin/
-COPY build/docker-init /usr/sbin/
-COPY build/update-ssh-keys /usr/bin/
-COPY build/rancheros-install /usr/sbin/
+COPY build/entry.sh build/console.sh build/docker-init build/update-ssh-keys build/rancheros-install /usr/sbin/
 RUN echo 'RancherOS \\n \l' > /etc/issue
 RUN locale-gen en_US.UTF-8
 RUN addgroup --gid 1100 rancher && \

--- a/src/docker/10-ubuntuconsole/Dockerfile
+++ b/src/docker/10-ubuntuconsole/Dockerfile
@@ -3,11 +3,7 @@ RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync vim curl ca-certificates
 RUN rm -rf /etc/ssh/*key*
-COPY build/entry.sh /usr/sbin/
-COPY build/console.sh /usr/sbin/
-COPY build/docker-init /usr/sbin/
-COPY build/update-ssh-keys /usr/bin/
-COPY build/rancheros-install /usr/sbin/
+COPY build/entry.sh build/console.sh build/docker-init build/update-ssh-keys build/rancheros-install /usr/sbin/
 RUN echo 'RancherOS \\n \l' > /etc/issue
 RUN locale-gen en_US.UTF-8
 RUN addgroup --gid 1100 rancher && \

--- a/src/docker/10-ubuntuconsole/Dockerfile
+++ b/src/docker/10-ubuntuconsole/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.2
+FROM ubuntu:14.04.3
 RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync vim curl ca-certificates


### PR DESCRIPTION
Do not write over /etc/lsb-release on every console launch. 
Do not customize /etc/lsb-release in ubuntu-console and debian-console. 
For commands like `add-apt-repository` it is highly desirable to leave 
the original /etc/lsb-release from the base image (ubuntu or debian).
