### PR TITLE
Fix `/usr/bin/docker` symlink not found in console

### DIFF
--- a/src/docker/02-console/Dockerfile
+++ b/src/docker/02-console/Dockerfile
@@ -7,5 +7,6 @@ RUN sed -i 's/rancher:!/rancher:*/g' /etc/shadow && \
     echo '## allow password less for rancher user' >> /etc/sudoers && \
     echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
     echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+    ln -sf /usr/bin/docker.dist /usr/bin/docker
 CMD ["/usr/sbin/console.sh"]

--- a/src/docker/10-debianconsole/Dockerfile
+++ b/src/docker/10-debianconsole/Dockerfile
@@ -13,6 +13,7 @@ RUN addgroup --gid 1100 rancher && \
     echo '## allow password less for rancher user' >> /etc/sudoers && \
     echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
     echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+    ln -sf /usr/bin/docker.dist /usr/bin/docker
 ENTRYPOINT ["/usr/sbin/entry.sh"]
 CMD ["/usr/sbin/console.sh"]

--- a/src/docker/10-ubuntuconsole/Dockerfile
+++ b/src/docker/10-ubuntuconsole/Dockerfile
@@ -13,6 +13,7 @@ RUN addgroup --gid 1100 rancher && \
     echo '## allow password less for rancher user' >> /etc/sudoers && \
     echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
     echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+    ln -sf /usr/bin/docker.dist /usr/bin/docker
 ENTRYPOINT ["/usr/sbin/entry.sh"]
 CMD ["/usr/sbin/console.sh"]


### PR DESCRIPTION
Fix `/usr/bin/docker` symlink not found in console when running docker with non-default storage context (e.g. nfs)
