### PR TITLE
Move /etc/hosts handling to network service

### DIFF
--- a/src/docker/02-console/console.sh
+++ b/src/docker/02-console/console.sh
@@ -107,10 +107,6 @@ BUG_REPORT_URL=
 BUILD_ID=
 EOF
 
-if ! grep -q "$(hostname)" /etc/hosts; then
-    echo 127.0.1.1 $(hostname) >> /etc/hosts
-fi
-
 echo 'RancherOS \n \l' > /etc/issue
 echo $(/sbin/ifconfig | grep -B1 "inet addr" |awk '{ if ( $1 == "inet" ) { print $2 } else if ( $2 == "Link" ) { printf "%s:" ,$1 } }' |awk -F: '{ print $1 ": " $3}') >> /etc/issue
 


### PR DESCRIPTION
Move /etc/hosts handling to network service

The code goes to network.go in rancher/os
