### PR TITLE
Add statescript image to run in bootstrap Docker

### DIFF
--- a/src/docker/02-statescript/Dockerfile
+++ b/src/docker/02-statescript/Dockerfile
@@ -1,0 +1,3 @@
+FROM rancher/os-base
+COPY state.sh /usr/sbin/
+CMD ["/usr/sbin/state.sh"]

--- a/src/docker/02-statescript/state.sh
+++ b/src/docker/02-statescript/state.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -x
+
+if [ "$(ros config get rancher.state.mdadm_scan)" = "true" ]; then
+    mdadm --assemble --scan
+fi
+
+ros config get rancher.state.script > config.sh
+if [ -s config.sh ]; then
+    chmod +x config.sh
+    exec ./config.sh
+fi


### PR DESCRIPTION
This also supports the rancher.state.mdadm_scan setting.
