### PR TITLE
fix resizefs on openstack

### DIFF
--- a/src/docker/10-resizefs/resizefs.sh
+++ b/src/docker/10-resizefs/resizefs.sh
@@ -15,7 +15,7 @@ p
 q
 EOF
   )
-  fdisk ${RESIZE_DEV} <<EOF
+  (fdisk ${RESIZE_DEV} <<EOF
 d
 n
 p
@@ -25,6 +25,9 @@ ${START}
 a
 w
 EOF
+  ) && fdisk_exit=0 || fdisk_exit=$?
+  [ "$fdisk_exit" -eq 0 ] || [[ "$FORCE" ]]
+  
   partprobe
   resize2fs ${RESIZE_DEV}1 || :
 else


### PR DESCRIPTION
Im trying to use rancheros on openstack. Instance are starting fine, but the partition isnt resized.
I stumbled upon: https://github.com/rancher/os/issues/232 so I've tried to add a custom cloud-config at startup:

```
#cloud-config
rancher:
  environment:
    RESIZE_DEV: /dev/vda
  services_include:
    https://raw.githubusercontent.com/rancher/os-services/v0.4.2-dev/r/resize-fs.yml: true
```

`fdisk` fails with:

```
Re-reading the partition table failed.: Device or resource busy
Command (m for help): The partition table has been altered.
Calling ioctl() to re-read partition table.

The kernel still uses the old table. The new table will be used at the next reboot or after you run partprobe(8) or kpartx(8).
```
