### PR TITLE
os-base: add /home directory

### DIFF
--- a/src/docker/01-base/Dockerfile
+++ b/src/docker/01-base/Dockerfile
@@ -14,6 +14,7 @@ RUN rm /sbin/poweroff /sbin/reboot /sbin/halt && \
        /var/spool \
        /var/lib/misc && \
     mkdir -p \
+       /home \
        /run \
        /var/cache \
        /var/lock \


### PR DESCRIPTION
when used os-base v2015.11.1-1, because buildroot v2015.11.1
remove the /home directory since:
https://git.busybox.net/buildroot/commit/?id=3dde19e5f32c58ffbf7e190257b073e91e0a7e8d

when there is no /home directory, the following command will failed:
    adduser -u 1100 -G rancher -D -h /home/rancher -s /bin/bash rancher

so fix it by this patch.

Signed-off-by: Wang Long long.wanglong@huawei.com
