### PR TITLE
remove '-f' in docker tag command

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -35,6 +35,6 @@ else
         else
             docker build -t rancher/${name} ${i}
         fi
-        docker tag -f rancher/${name} ${tag}
+        docker tag rancher/${name} ${tag}
     done
 fi

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,7 +30,11 @@ else
         if [ -x ${i}/.prebuild.sh ]; then
             ${i}/.prebuild.sh;
         fi
-        docker build -t rancher/${name} ${i}
+        if [ -f ${i}/Dockerfile.${ARCH} ]; then
+            docker build -t rancher/${name} -f ${i}/Dockerfile.${ARCH} ${i}
+        else
+            docker build -t rancher/${name} ${i}
+        fi
         docker tag -f rancher/${name} ${tag}
     done
 fi


### PR DESCRIPTION
when we use lastest version of docker, the '-f' is deprecated. like:

```
ubuntu@ubuntu:~/docker-from-scratch$ docker tag -f ubuntu:14.04 ubuntu:myself
Warning: '-f' is deprecated, it will be removed soon. See usage.
ubuntu@ubuntu:~/docker-from-scratch$ docker version
Client:
 Version:      1.10.0-dev
 API version:  1.22
 Go version:   go1.5.1
 Git commit:   9165700
 Built:        Mon Dec  7 17:59:10 2015
 OS/Arch:      linux/arm64

Server:
 Version:      1.10.0-dev
 API version:  1.22
 Go version:   go1.5.1
 Git commit:   9165700
 Built:        Mon Dec  7 17:59:10 2015
 OS/Arch:      linux/arm64
```

so just remove it.

Signed-off-by: Wang Long long.wanglong@huawei.com
