### PR TITLE
Use base images from "armhf" org for consoles & resizefs

### DIFF
--- a/.amd64.base-images
+++ b/.amd64.base-images
@@ -1,0 +1,4 @@
+DEBIAN_BASE_IMAGE="debian:jessie"
+UBUNTU_BASE_IMAGE="ubuntu:14.04.3"
+FEDORA_BASE_IMAGE="fedora:23"
+CENTOS_BASE_IMAGE="centos:7"

--- a/.arm.base-images
+++ b/.arm.base-images
@@ -1,0 +1,4 @@
+DEBIAN_BASE_IMAGE="resin/rpi-raspbian:jessie"
+UBUNTU_BASE_IMAGE="armhf/ubuntu:14.04"
+FEDORA_BASE_IMAGE="armv7/armhf-fedora:23"
+CENTOS_BASE_IMAGE="armhfbuild/centos:7"

--- a/src/docker/10-centosconsole/.prebuild.sh
+++ b/src/docker/10-centosconsole/.prebuild.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# FIXME Remove this when Docker supplies multi-arch base images
+. .$ARCH.base-images
+[[ -n "$(docker images -q $CENTOS_BASE_IMAGE 2> /dev/null)" ]] || docker pull $CENTOS_BASE_IMAGE
+docker tag -f $CENTOS_BASE_IMAGE rancher/os-centosconsole-base
+
 cd $(dirname $0)
 
 rm -rf ./build

--- a/src/docker/10-centosconsole/Dockerfile
+++ b/src/docker/10-centosconsole/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM rancher/os-centosconsole-base
 RUN yum upgrade -y && \
     yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop
 RUN rm -rf /etc/ssh/*key*

--- a/src/docker/10-debianconsole/.prebuild.sh
+++ b/src/docker/10-debianconsole/.prebuild.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# FIXME Remove this when Docker supplies multi-arch base images
+. .$ARCH.base-images
+[[ -n "$(docker images -q $DEBIAN_BASE_IMAGE 2> /dev/null)" ]] || docker pull $DEBIAN_BASE_IMAGE
+docker tag -f $DEBIAN_BASE_IMAGE rancher/os-debianconsole-base
+
 cd $(dirname $0)
 
 rm -rf ./build

--- a/src/docker/10-debianconsole/Dockerfile
+++ b/src/docker/10-debianconsole/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM rancher/os-debianconsole-base
 RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop

--- a/src/docker/10-fedoraconsole/.prebuild.sh
+++ b/src/docker/10-fedoraconsole/.prebuild.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# FIXME Remove this when Docker supplies multi-arch base images
+. .$ARCH.base-images
+[[ -n "$(docker images -q $FEDORA_BASE_IMAGE 2> /dev/null)" ]] || docker pull $FEDORA_BASE_IMAGE
+docker tag -f $FEDORA_BASE_IMAGE rancher/os-fedoraconsole-base
+
 cd $(dirname $0)
 
 rm -rf ./build

--- a/src/docker/10-fedoraconsole/Dockerfile
+++ b/src/docker/10-fedoraconsole/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:23
+FROM rancher/os-fedoraconsole-base
 RUN dnf upgrade -y && \
     dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop
 RUN rm -rf /etc/ssh/*key*

--- a/src/docker/10-resizefs/.prebuild.sh
+++ b/src/docker/10-resizefs/.prebuild.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# FIXME Remove this when Docker supplies multi-arch base images
+. .$ARCH.base-images
+[[ -n "$(docker images -q $DEBIAN_BASE_IMAGE 2> /dev/null)" ]] || docker pull $DEBIAN_BASE_IMAGE
+docker tag -f $DEBIAN_BASE_IMAGE rancher/os-resizefs-base

--- a/src/docker/10-resizefs/Dockerfile
+++ b/src/docker/10-resizefs/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM rancher/os-resizefs-base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends parted && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/src/docker/10-ubuntuconsole/.prebuild.sh
+++ b/src/docker/10-ubuntuconsole/.prebuild.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# FIXME Remove this when Docker supplies multi-arch base images
+. .$ARCH.base-images
+[[ -n "$(docker images -q $UBUNTU_BASE_IMAGE 2> /dev/null)" ]] || docker pull $UBUNTU_BASE_IMAGE
+docker tag -f $UBUNTU_BASE_IMAGE rancher/os-ubuntuconsole-base
+
 cd $(dirname $0)
 
 rm -rf ./build

--- a/src/docker/10-ubuntuconsole/Dockerfile
+++ b/src/docker/10-ubuntuconsole/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.3
+FROM rancher/os-ubuntuconsole-base
 RUN apt-get update && \
     apt-get upgrade --no-install-recommends -y && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync vim curl ca-certificates psmisc htop


### PR DESCRIPTION
This is a temporary measure to get the consoles working on ARM until Docker supplies real multi-arch base images.

I can understand anyone who considers this a hack. So feel free not to accept this PR ;)
