### PR TITLE
Wait for Docker to start before running /etc/rc.local

### DIFF
--- a/src/docker/02-console/console.sh
+++ b/src/docker/02-console/console.sh
@@ -128,6 +128,10 @@ fi
 
 touch /run/console-done
 
+for ((i=0;i<10;i++)); do
+    docker version >/dev/null 2>&1 && break || sleep 1
+done
+
 if [ -x /etc/rc.local ]; then
     echo Executing rc.local
     /etc/rc.local || true


### PR DESCRIPTION
This kills two birds with one stone.  One, it makes the behaviour of
/etc/rc.local more consistent in that you can assume that user Docker is
running.  Second, it prevents a race condition that causes ctrl+c to not
work.
