### PR TITLE
Fix preload

### DIFF
--- a/src/docker/02-preload/Dockerfile
+++ b/src/docker/02-preload/Dockerfile
@@ -1,3 +1,4 @@
 FROM rancher/os-base
+RUN ln -sf /usr/bin/docker.dist /usr/bin/docker
 COPY preload.sh  /
 CMD ["/preload.sh"]

--- a/src/docker/02-preload/preload.sh
+++ b/src/docker/02-preload/preload.sh
@@ -8,7 +8,7 @@ should_load() {
     file=${1}
     if [[ ${file} =~ \.done$ ]]; then echo false
     elif [ -f ${file} ]; then
-        if [[ ${file} -nt ${file)}.done ]]; then echo true
+        if [[ ${file} -nt ${file}.done ]]; then echo true
         else echo false
         fi
     else echo false

--- a/src/docker/02-preload/preload.sh
+++ b/src/docker/02-preload/preload.sh
@@ -8,9 +8,7 @@ should_load() {
     file=${1}
     if [[ ${file} =~ \.done$ ]]; then echo false
     elif [ -f ${file} ]; then
-        if [ ! -e ${file}.done ]; then echo true
-        # Removing updated behavior until `stat` returns
-        #elif [[ $(stat -c %Y ${file}) > $(stat -c %Y ${file}.done) ]]; then echo true
+        if [[ ${file} -nt ${file)}.done ]]; then echo true
         else echo false
         fi
     else echo false

--- a/src/docker/02-preload/preload.sh
+++ b/src/docker/02-preload/preload.sh
@@ -9,7 +9,8 @@ should_load() {
     if [[ ${file} =~ \.done$ ]]; then echo false
     elif [ -f ${file} ]; then
         if [ ! -e ${file}.done ]; then echo true
-        elif [[ $(stat -c %Y ${file}) > $(stat -c %Y ${file}.done) ]]; then echo true
+        # Removing updated behavior until `stat` returns
+        #elif [[ $(stat -c %Y ${file}) > $(stat -c %Y ${file}.done) ]]; then echo true
         else echo false
         fi
     else echo false


### PR DESCRIPTION
The current preload image suffers from both a missing `stat` and a missing `docker` binary.

This PR removes the feature needing `stat` for now (but see: https://github.com/rancher/os-base/pull/24).  It also applies the same symlink that is used in the console containers to find `docker`.

You can test these changes with `outstand/os-preload:v0.4.3-rc4-1`.
