### PR TITLE
fix systemctl error

### DIFF
--- a/src/docker/10-centosconsole/Dockerfile
+++ b/src/docker/10-centosconsole/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7
 RUN yum upgrade -y && \
     yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop
 RUN rm -rf /etc/ssh/*key*
+RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 COPY build/entry.sh build/console.sh build/docker-init build/update-ssh-keys build/rancheros-install /usr/sbin/
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
 RUN groupadd --gid 1100 rancher && \

--- a/src/docker/10-fedoraconsole/Dockerfile
+++ b/src/docker/10-fedoraconsole/Dockerfile
@@ -2,6 +2,7 @@ FROM fedora:23
 RUN dnf upgrade -y && \
     dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop
 RUN rm -rf /etc/ssh/*key*
+RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 COPY build/entry.sh build/console.sh build/docker-init build/update-ssh-keys build/rancheros-install /usr/sbin/
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
 RUN groupadd --gid 1100 rancher && \

--- a/src/docker/10-selinuxtools/Dockerfile
+++ b/src/docker/10-selinuxtools/Dockerfile
@@ -10,6 +10,7 @@ RUN cd /usr/src/refpolicy && git submodule init && git submodule update && \
     make conf && make && make install-headers
 
 RUN rm -rf /etc/ssh/*key*
+RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 COPY build/entry.sh build/console.sh build/docker-init build/update-ssh-keys build/rancheros-install /usr/sbin/
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
 RUN groupadd --gid 1100 rancher && \


### PR DESCRIPTION
when we enable centosconsole/fedoraconsole, the `systemctl` command
will broken, because the reboot/shutdown/halt/poweroff in the console
are linked to systemctl.

[root@815a9b2ebc81 /]# ls -l /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt
lrwxrwxrwx 1 root root 16 Feb 15 23:08 /sbin/halt -> ../bin/systemctl
lrwxrwxrwx 1 root root 16 Feb 15 23:08 /sbin/poweroff -> ../bin/systemctl
lrwxrwxrwx 1 root root 16 Feb 15 23:08 /sbin/reboot -> ../bin/systemctl
lrwxrwxrwx 1 root root 16 Feb 15 23:08 /sbin/shutdown -> ../bin/systemctl

we run console os with the following:

   -v /home/wanglong/os/bin/ros:/sbin/reboot:ro

the `systemctl` command will be replace with `ros` command.

So delete these soft links when we create the console os images.

Signed-off-by: Wang Long long.wanglong@huawei.com
