### PR TITLE
build different architecture docker image with different dockerfile and remove -f flag in docker tag command

### DIFF
--- a/scripts/build-images
+++ b/scripts/build-images
@@ -35,6 +35,6 @@ else
         else
             docker build -t rancher/${name} ${i}
         fi
-        docker tag -f rancher/${name} ${tag}
+        docker tag rancher/${name} ${tag}
     done
 fi

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -30,7 +30,11 @@ else
         if [ -x ${i}/.prebuild.sh ]; then
             ${i}/.prebuild.sh;
         fi
-        docker build -t rancher/${name} ${i}
+        if [ -f ${i}/Dockerfile.${ARCH} ]; then
+            docker build -t rancher/${name} -f ${i}/Dockerfile.${ARCH} ${i}
+        else
+            docker build -t rancher/${name} ${i}
+        fi
         docker tag -f rancher/${name} ${tag}
     done
 fi


### PR DESCRIPTION
When building ARM64 docker images(os-ubuntuconsole), we using `FROM
aarch64/ubuntu` in the first line of the Dockerfile.aarch64, it is different for the x86 architecture.

So, we need the ability to build different archiecture images  with
different Dockerfile. Using Dockerfile.${ARCH} is a easy way to achieved this.
