### PR TITLE
Switch open-vm-tools base image to Ubuntu

### DIFF
--- a/images/10-openvmtools/Dockerfile
+++ b/images/10-openvmtools/Dockerfile
@@ -1,3 +1,5 @@
-FROM alpine:3.4
+FROM ubuntu:16.04
 # FROM arm=skip arm64=skip
-RUN apk update && apk add open-vm-tools
+RUN apt-get update && \
+    apt-get install -y open-vm-tools && \
+    rm -rf /var/lib/apt/*


### PR DESCRIPTION
As discussed in rancher/os#1096, the Alpine open-vm-tools package doesn't seem to be working. I've tested the Ubuntu package and it seems to be working well, so we should switch to this for now.
