### PR TITLE
Remove rancheros-install script

### DIFF
--- a/images/02-console/rancheros-install
+++ b/images/02-console/rancheros-install
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-
-cat <<EOF
-As of RancherOS v0.4.0 'rancheros-install' is obsolete.
-Please use 'ros install' instead.
-EOF
-
-exit 1

--- a/images/10-centosconsole/Dockerfile
+++ b/images/10-centosconsole/Dockerfile
@@ -5,7 +5,7 @@ RUN yum upgrade -y && \
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 RUN ln -s /sbin/agetty /sbin/getty
-COPY build/update-ssh-keys build/rancheros-install /usr/sbin/
+COPY build/update-ssh-keys /usr/sbin/
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
 RUN groupadd --gid 1100 rancher && \
     groupadd --gid 1101 docker && \

--- a/images/10-centosconsole/prebuild.sh
+++ b/images/10-centosconsole/prebuild.sh
@@ -6,4 +6,3 @@ cd $(dirname $0)
 rm -rf ./build
 mkdir -p ./build
 cp ./../02-console/update-ssh-keys ./build/
-cp ./../02-console/rancheros-install ./build/

--- a/images/10-debianconsole/Dockerfile
+++ b/images/10-debianconsole/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
-COPY build/update-ssh-keys build/rancheros-install /usr/sbin/
+COPY build/update-ssh-keys /usr/sbin/
 RUN locale-gen en_US.UTF-8
 RUN addgroup --gid 1100 rancher && \
     addgroup --gid 1101 docker && \

--- a/images/10-debianconsole/prebuild.sh
+++ b/images/10-debianconsole/prebuild.sh
@@ -6,4 +6,3 @@ cd $(dirname $0)
 rm -rf ./build
 mkdir -p ./build
 cp ./../02-console/update-ssh-keys ./build/
-cp ./../02-console/rancheros-install ./build/

--- a/images/10-fedoraconsole/Dockerfile
+++ b/images/10-fedoraconsole/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf upgrade -y && \
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 RUN ln -s /sbin/agetty /sbin/getty
-COPY build/update-ssh-keys build/rancheros-install /usr/sbin/
+COPY build/update-ssh-keys /usr/sbin/
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
 RUN groupadd --gid 1100 rancher && \
     groupadd --gid 1101 docker && \

--- a/images/10-fedoraconsole/prebuild.sh
+++ b/images/10-fedoraconsole/prebuild.sh
@@ -6,4 +6,3 @@ cd $(dirname $0)
 rm -rf ./build
 mkdir -p ./build
 cp ./../02-console/update-ssh-keys ./build/
-cp ./../02-console/rancheros-install ./build/

--- a/images/10-selinuxtools/Dockerfile
+++ b/images/10-selinuxtools/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf upgrade -y && \
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 RUN ln -s /sbin/agetty /sbin/getty
-COPY build/update-ssh-keys build/rancheros-install /usr/sbin/
+COPY build/update-ssh-keys /usr/sbin/
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
 RUN groupadd --gid 1100 rancher && \
     groupadd --gid 1101 docker && \

--- a/images/10-selinuxtools/prebuild.sh
+++ b/images/10-selinuxtools/prebuild.sh
@@ -6,4 +6,3 @@ cd $(dirname $0)
 rm -rf ./build
 mkdir -p ./build
 cp ./../02-console/update-ssh-keys ./build/
-cp ./../02-console/rancheros-install ./build/

--- a/images/10-ubuntuconsole/Dockerfile
+++ b/images/10-ubuntuconsole/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2
 RUN rm -rf /etc/ssh/*key*
 RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
-COPY build/update-ssh-keys build/rancheros-install /usr/sbin/
+COPY build/update-ssh-keys /usr/sbin/
 RUN locale-gen en_US.UTF-8
 RUN addgroup --gid 1100 rancher && \
     addgroup --gid 1101 docker && \

--- a/images/10-ubuntuconsole/prebuild.sh
+++ b/images/10-ubuntuconsole/prebuild.sh
@@ -6,4 +6,3 @@ cd $(dirname $0)
 rm -rf ./build
 mkdir -p ./build
 cp ./../02-console/update-ssh-keys ./build/
-cp ./../02-console/rancheros-install ./build/


### PR DESCRIPTION
This script hasn't been used since the v0.2 or v0.3 series, so there isn't much reason to include this warning anymore.