### PR TITLE
Remove CMD from console images

### DIFF
--- a/images/10-centosconsole/Dockerfile
+++ b/images/10-centosconsole/Dockerfile
@@ -22,4 +22,3 @@ RUN groupadd --gid 1100 rancher && \
     ln -sf /usr/bin/docker-runc.dist /usr/bin/docker-runc
 COPY prompt.sh /etc/profile.d/
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]
-CMD ["/usr/sbin/console.sh"]

--- a/images/10-debianconsole/Dockerfile
+++ b/images/10-debianconsole/Dockerfile
@@ -21,4 +21,3 @@ RUN addgroup --gid 1100 rancher && \
     ln -sf /usr/bin/docker-containerd-shim.dist /usr/bin/docker-containerd-shim && \
     ln -sf /usr/bin/docker-runc.dist /usr/bin/docker-runc
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]
-CMD ["/usr/sbin/console.sh"]

--- a/images/10-fedoraconsole/Dockerfile
+++ b/images/10-fedoraconsole/Dockerfile
@@ -22,4 +22,3 @@ RUN groupadd --gid 1100 rancher && \
     ln -sf /usr/bin/docker-runc.dist /usr/bin/docker-runc
 COPY prompt.sh /etc/profile.d/
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]
-CMD ["/usr/sbin/console.sh"]

--- a/images/10-ubuntuconsole/Dockerfile
+++ b/images/10-ubuntuconsole/Dockerfile
@@ -21,4 +21,3 @@ RUN addgroup --gid 1100 rancher && \
     ln -sf /usr/bin/docker-containerd-shim.dist /usr/bin/docker-containerd-shim && \
     ln -sf /usr/bin/docker-runc.dist /usr/bin/docker-runc
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]
-CMD ["/usr/sbin/console.sh"]


### PR DESCRIPTION
rancher/os#1338 changes the console command. I can update the command here, but I think it would make more sense to move the command to the service definition. This would be one less thing to add when building a new console.
