### PR TITLE
move the Docker engine image builds into the os-images repo

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -53,5 +53,26 @@ RUN curl -fL ${!DOCKER_URL} > /usr/bin/docker && \
 RUN curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m | sed 's/arm.*/arm/'` > /usr/bin/dapper && \
     chmod +x /usr/bin/dapper
 
+# Download Docker engines
+RUN mkdir -p /assets/docker-1.10.3 && \
+    curl -sL https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 > /assets/docker-1.10.3/docker && \
+    chmod +x /assets/docker-1.10.3/docker
+RUN mkdir -p /assets/docker-1.10.3_arm && \
+    curl -sL https://github.com/rancher/docker/releases/download/v1.10.3-arm/docker-1.10.3_arm > /assets/docker-1.10.3_arm/docker && \
+    chmod +x /assets/docker-1.10.3_arm/docker
+RUN mkdir -p /assets/docker-1.10.3_arm64 && \
+    curl -sL https://github.com/rancher/docker/releases/download/v1.10.3-arm64/docker-1.10.3_arm64 > /assets/docker-1.10.3_arm64/docker && \
+    chmod +x /assets/docker-1.10.3_arm/docker
+RUN curl -sfL https://get.docker.com/builds/Linux/x86_64/docker-1.11.2.tgz | tar xzf - -C /assets && \
+    mv /assets/docker /assets/docker-1.11.2
+RUN curl -sfL https://github.com/rancher/docker/releases/download/v1.11.2-ros1/docker-1.11.2_arm.tgz | tar xzf - -C /assets && \
+    mv /assets/docker /assets/docker-1.11.2_arm
+RUN curl -sfL https://github.com/rancher/docker/releases/download/v1.11.2-ros1/docker-1.11.2_arm64.tgz | tar xzf - -C /assets && \
+    mv /assets/docker /assets/docker-1.11.2_arm64
+RUN curl -sfL https://get.docker.com/builds/Linux/x86_64/docker-1.12.1.tgz | tar xzf - -C /assets && \
+    mv /assets/docker /assets/docker-1.12.1
+
+ENV TEST=1
+
 ENTRYPOINT ["./scripts/entry"]
 CMD ["ci"]

--- a/images/10-docker-1.10.3/Dockerfile
+++ b/images/10-docker-1.10.3/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.10.3/prebuild.sh
+++ b/images/10-docker-1.10.3/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.10.3 ./images/10-docker-1.10.3/engine

--- a/images/10-docker-1.10.3_arm/Dockerfile
+++ b/images/10-docker-1.10.3_arm/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.10.3_arm/prebuild.sh
+++ b/images/10-docker-1.10.3_arm/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.10.3_arm ./images/10-docker-1.10.3_arm/engine

--- a/images/10-docker-1.10.3_arm64/Dockerfile
+++ b/images/10-docker-1.10.3_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.10.3_arm64/prebuild.sh
+++ b/images/10-docker-1.10.3_arm64/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.10.3_arm64 ./images/10-docker-1.10.3_arm64/engine

--- a/images/10-docker-1.11.2/Dockerfile
+++ b/images/10-docker-1.11.2/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.11.2/prebuild.sh
+++ b/images/10-docker-1.11.2/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.11.2 ./images/10-docker-1.11.2/engine

--- a/images/10-docker-1.11.2_arm/Dockerfile
+++ b/images/10-docker-1.11.2_arm/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.11.2_arm/prebuild.sh
+++ b/images/10-docker-1.11.2_arm/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.11.2_arm ./images/10-docker-1.11.2_arm/engine

--- a/images/10-docker-1.11.2_arm64/Dockerfile
+++ b/images/10-docker-1.11.2_arm64/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.11.2_arm64/prebuild.sh
+++ b/images/10-docker-1.11.2_arm64/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.11.2_arm64 ./images/10-docker-1.11.2_arm64/engine

--- a/images/10-docker-1.12.1/Dockerfile
+++ b/images/10-docker-1.12.1/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY engine /engine

--- a/images/10-docker-1.12.1/prebuild.sh
+++ b/images/10-docker-1.12.1/prebuild.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cp -r /assets/docker-1.12.1 ./images/10-docker-1.12.1/engine

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -12,7 +12,15 @@ mkdir -p dist
 
 for i in $BASE/[1-9]*; do
     name="os-$(echo ${i} | cut -f2 -d-)"
+
+    if [ "$name" == "os-docker" ]; then
+        # VERSION tag for docker engine images
+        IFS='-' read -ra dirname <<< "$i"
+        VERSION=${dirname[2]}
+    fi
+
     tag="${OS_REPO}/${name}:${VERSION}${SUFFIX}"
+    # TODO: try pulling an existing image first
     echo Building ${tag}
     if [ -e ${i}/prebuild.sh ]; then
         ${i}/prebuild.sh


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

step 1 of many simplifications :)

@ibuildthecloud @joshwget 

because we're not really versioning anything in the os-engines repo, i recon we can just delete it.

