### PR TITLE
Don't upgrade base images - it pulls in things you probably don't want

### DIFF
--- a/images/10-centosconsole/Dockerfile
+++ b/images/10-centosconsole/Dockerfile
@@ -1,20 +1,19 @@
 FROM rancher/os-centosconsole-base
 # FROM amd64=centos:7 arm64=skip arm=skip
-RUN yum upgrade -y && \
-    yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng
-RUN rm -rf /etc/ssh/*key*
-RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
-RUN ln -s /sbin/agetty /sbin/getty
+RUN yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
+    && rm -rf /etc/ssh/*key* \
+    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt \
+    && ln -s /sbin/agetty /sbin/getty
 COPY build/update-ssh-keys /usr/sbin/
-RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
-RUN groupadd --gid 1100 rancher && \
-    groupadd --gid 1101 docker && \
-    useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher && \
-    useradd -u 1101 -g docker -G docker,wheel -m -s /bin/bash docker && \
-    echo ClientAliveInterval 180 >> /etc/ssh/sshd_config && \
-    echo '## allow password less for rancher user' >> /etc/sudoers && \
-    echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8 \
+    && groupadd --gid 1100 rancher \
+    && groupadd --gid 1101 docker \
+    && useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher \
+    && useradd -u 1101 -g docker -G docker,wheel -m -s /bin/bash docker \
+    && echo ClientAliveInterval 180 >> /etc/ssh/sshd_config \
+    && echo '## allow password less for rancher user' >> /etc/sudoers \
+    && echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && echo '## allow password less for docker user' >> /etc/sudoers \
+    && echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 COPY prompt.sh /etc/profile.d/
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/10-debianconsole/Dockerfile
+++ b/images/10-debianconsole/Dockerfile
@@ -1,19 +1,19 @@
 FROM rancher/os-debianconsole-base
 # FROM amd64=debian:jessie arm64=aarch64/debian:jessie arm=resin/rpi-raspbian:jessie
-RUN apt-get update && \
-    apt-get upgrade --no-install-recommends -y && \
-    apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2
-RUN rm -rf /etc/ssh/*key*
-RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2 \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /etc/ssh/*key* \
+    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 COPY build/update-ssh-keys /usr/sbin/
-RUN locale-gen en_US.UTF-8
-RUN addgroup --gid 1100 rancher && \
-    addgroup --gid 1101 docker && \
-    useradd -u 1100 -g rancher -G docker,sudo -m -s /bin/bash rancher && \
-    useradd -u 1101 -g docker -G docker,sudo -m -s /bin/bash docker && \
-    echo ClientAliveInterval 180 >> /etc/ssh/sshd_config && \
-    echo '## allow password less for rancher user' >> /etc/sudoers && \
-    echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN locale-gen en_US.UTF-8 \
+    && addgroup --gid 1100 rancher \
+    && addgroup --gid 1101 docker \
+    && useradd -u 1100 -g rancher -G docker,sudo -m -s /bin/bash rancher \
+    && useradd -u 1101 -g docker -G docker,sudo -m -s /bin/bash docker \
+    && echo ClientAliveInterval 180 >> /etc/ssh/sshd_config \
+    && echo '## allow password less for rancher user' >> /etc/sudoers \
+    &&  echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && echo '## allow password less for docker user' >> /etc/sudoers \
+    && echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/10-fedoraconsole/Dockerfile
+++ b/images/10-fedoraconsole/Dockerfile
@@ -1,20 +1,19 @@
 FROM rancher/os-fedoraconsole-base
 # FROM amd64=fedora:23 arm64=rancher/aarch64-fedora:23 arm=skip
-RUN dnf upgrade -y && \
-    dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng
-RUN rm -rf /etc/ssh/*key*
-RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
-RUN ln -s /sbin/agetty /sbin/getty
+RUN dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
+    && rm -rf /etc/ssh/*key* \
+    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt \
+    && ln -s /sbin/agetty /sbin/getty
 COPY build/update-ssh-keys /usr/sbin/
-RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
-RUN groupadd --gid 1100 rancher && \
-    groupadd --gid 1101 docker && \
-    useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher && \
-    useradd -u 1101 -g docker -G docker,wheel -m -s /bin/bash docker && \
-    echo ClientAliveInterval 180 >> /etc/ssh/sshd_config && \
-    echo '## allow password less for rancher user' >> /etc/sudoers && \
-    echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8 \
+    && groupadd --gid 1100 rancher \
+    && groupadd --gid 1101 docker \
+    && useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher \
+    && useradd -u 1101 -g docker -G docker,wheel -m -s /bin/bash docker \
+    && echo ClientAliveInterval 180 >> /etc/ssh/sshd_config \
+    && echo '## allow password less for rancher user' >> /etc/sudoers \
+    && echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && echo '## allow password less for docker user' >> /etc/sudoers \
+    && echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 COPY prompt.sh /etc/profile.d/
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/10-openvmtools/Dockerfile
+++ b/images/10-openvmtools/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:16.04
 # FROM arm=skip arm64=skip
-RUN apt-get update && \
-    apt-get install -y open-vm-tools && \
-    rm -rf /var/lib/apt/*
+RUN apt-get update \
+    && apt-get install -y open-vm-tools \
+    && rm -rf /var/lib/apt/*

--- a/images/10-selinuxtools/Dockerfile
+++ b/images/10-selinuxtools/Dockerfile
@@ -1,29 +1,27 @@
 FROM rancher/os-fedoraconsole-base
 # FROM amd64=fedora:23 arm64=rancher/aarch64-fedora:23 arm=skip
-RUN dnf upgrade -y && \
-    dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng
-RUN rm -rf /etc/ssh/*key*
-RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
-RUN ln -s /sbin/agetty /sbin/getty
+RUN dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
+    && rm -rf /etc/ssh/*key* \
+    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt \
+    && ln -s /sbin/agetty /sbin/getty
 COPY build/update-ssh-keys /usr/sbin/
-RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8
-RUN groupadd --gid 1100 rancher && \
-    groupadd --gid 1101 docker && \
-    useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher && \
-    useradd -u 1101 -g docker -G docker,wheel -m -s /bin/bash docker && \
-    echo ClientAliveInterval 180 >> /etc/ssh/sshd_config && \
-    echo '## allow password less for rancher user' >> /etc/sudoers && \
-    echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    ln -sf /usr/bin/docker.dist /usr/bin/docker
+RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8 \
+    &&  groupadd --gid 1100 rancher \
+    && groupadd --gid 1101 docker \
+    && useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher \
+    && useradd -u 1101 -g docker -G docker,wheel -m -s /bin/bash docker \
+    && echo ClientAliveInterval 180 >> /etc/ssh/sshd_config \
+    && echo '## allow password less for rancher user' >> /etc/sudoers \
+    && echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && echo '## allow password less for docker user' >> /etc/sudoers \
+    && echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && ln -sf /usr/bin/docker.dist /usr/bin/docker
 COPY prompt.sh /etc/profile.d/
 
-RUN dnf install -y git make gcc findutils selinux-policy-devel setools-console setools-devel
-
-RUN git clone https://github.com/rancher/refpolicy.git /usr/src/refpolicy
-RUN cd /usr/src/refpolicy && git submodule init && git submodule update && \
-    sed -i '/MONOLITHIC = y/c\MONOLITHIC = n' build.conf && \
-    make conf && make && make install-headers
+RUN dnf install -y git make gcc findutils selinux-policy-devel setools-console setools-devel \
+    && git clone https://github.com/rancher/refpolicy.git /usr/src/refpolicy \
+    && cd /usr/src/refpolicy && git submodule init && git submodule update \
+    && sed -i '/MONOLITHIC = y/c\MONOLITHIC = n' build.conf \
+    && make conf && make && make install-headers
 
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/10-ubuntuconsole/Dockerfile
+++ b/images/10-ubuntuconsole/Dockerfile
@@ -1,19 +1,19 @@
 FROM rancher/os-ubuntuconsole-base
 # FROM amd64=ubuntu:16.04 arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
-RUN apt-get update && \
-    apt-get upgrade --no-install-recommends -y && \
-    apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2
-RUN rm -rf /etc/ssh/*key*
-RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2 \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /etc/ssh/*key* \
+    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 COPY build/update-ssh-keys /usr/sbin/
-RUN locale-gen en_US.UTF-8
-RUN addgroup --gid 1100 rancher && \
-    addgroup --gid 1101 docker && \
-    useradd -u 1100 -g rancher -G docker,sudo -m -s /bin/bash rancher && \
-    useradd -u 1101 -g docker -G docker,sudo -m -s /bin/bash docker && \
-    echo ClientAliveInterval 180 >> /etc/ssh/sshd_config && \
-    echo '## allow password less for rancher user' >> /etc/sudoers && \
-    echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    echo '## allow password less for docker user' >> /etc/sudoers && \
-    echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+RUN locale-gen en_US.UTF-8 \
+    && addgroup --gid 1100 rancher \
+    && addgroup --gid 1101 docker \
+    && useradd -u 1100 -g rancher -G docker,sudo -m -s /bin/bash rancher \
+    && useradd -u 1101 -g docker -G docker,sudo -m -s /bin/bash docker \
+    && echo ClientAliveInterval 180 >> /etc/ssh/sshd_config \
+    && echo '## allow password less for rancher user' >> /etc/sudoers \
+    && echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers \
+    && echo '## allow password less for docker user' >> /etc/sudoers \
+    && echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
 ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/20-xfce/Dockerfile
+++ b/images/20-xfce/Dockerfile
@@ -1,7 +1,8 @@
 FROM rancher/os-ubuntuconsole
 # FROM arm64=skip arm=skip
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y xfce4 slim xfce4-terminal && \
-    apt-get autoremove -y
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y xfce4 slim xfce4-terminal \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 COPY desktop.sh /usr/bin/desktop.sh
 CMD ["desktop.sh"]


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

I noticed that the fedora console was ~800MB - I'm going to guess that upgrading it pulled in lots of non-container packages?

before change:

```
25.51 MB		rancher/os-acpid:40f413f-dirty
25.51 MB		rancher/os-base:40f413f-dirty
25.51 MB		rancher/os-bootstrap:40f413f-dirty
25.51 MB		rancher/os-cloudinit:40f413f-dirty
25.52 MB		rancher/os-console:40f413f-dirty
98.19 MB		rancher/os-docker:1.12.1
25.51 MB		rancher/os-syslog:40f413f-dirty
426.7 MB		rancher/os-centosconsole:e2a500e
206.9 MB		rancher/os-debianconsole:e2a500e
9.109 MB		rancher/os-extras:e2a500e
810.7 MB		rancher/os-fedoraconsole:e2a500e
25.51 MB		rancher/os-headers:e2a500e
175.7 MB		rancher/os-openvmtools:e2a500e
289.9 MB		rancher/os-ubuntuconsole:e2a500e
```

after change:

```
25.51 MB		rancher/os-acpid:c93dbe6
25.51 MB		rancher/os-base:c93dbe6
25.51 MB		rancher/os-bootstrap:c93dbe6
25.51 MB		rancher/os-cloudinit:c93dbe6
25.52 MB		rancher/os-console:c93dbe6
98.19 MB		rancher/os-docker:1.12.1
25.51 MB		rancher/os-syslog:c93dbe6
368.3 MB		rancher/os-centosconsole:e2a500e-dirty
195.7 MB		rancher/os-debianconsole:e2a500e-dirty
9.109 MB		rancher/os-extras:e2a500e-dirty
424.1 MB		rancher/os-fedoraconsole:e2a500e-dirty
25.51 MB		rancher/os-headers:e2a500e-dirty
175.7 MB		rancher/os-openvmtools:e2a500e-dirty
216.7 MB		rancher/os-ubuntuconsole:e2a500e-dirty
```