### PR TITLE
Don't remove power operations in consoles

### DIFF
--- a/images/10-alpineconsole/Dockerfile
+++ b/images/10-alpineconsole/Dockerfile
@@ -3,7 +3,6 @@ FROM rancher/os-alpineconsole-base
 RUN apk --no-cache add bash openssh iptables rsync sudo vim less curl ca-certificates htop kmod iproute2 util-linux
 # missing packages at 2016-Nov: locales psmisc
 RUN rm -rf /etc/ssh/*key*
-RUN rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
 #RUN ln -s /sbin/getty /sbin/agetty
 #RUN locale-gen en_US.UTF-8
 RUN addgroup -g 1100 rancher && \

--- a/images/10-centosconsole/Dockerfile
+++ b/images/10-centosconsole/Dockerfile
@@ -2,7 +2,6 @@ FROM rancher/os-centosconsole-base
 # FROM amd64=centos:7 arm64=skip arm=skip
 RUN yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
     && rm -rf /etc/ssh/*key* \
-    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt \
     && ln -s /sbin/agetty /sbin/getty
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8 \
     && groupadd --gid 1100 rancher \

--- a/images/10-debianconsole/Dockerfile
+++ b/images/10-debianconsole/Dockerfile
@@ -3,8 +3,7 @@ FROM rancher/os-debianconsole-base
 RUN apt-get update \
     && apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2 \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /etc/ssh/*key* \
-    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
+    && rm -rf /etc/ssh/*key*
 RUN locale-gen en_US.UTF-8 \
     && addgroup --gid 1100 rancher \
     && addgroup --gid 1101 docker \

--- a/images/10-fedoraconsole/Dockerfile
+++ b/images/10-fedoraconsole/Dockerfile
@@ -2,7 +2,6 @@ FROM rancher/os-fedoraconsole-base
 # FROM amd64=fedora:24 arm64=skip arm=skip
 RUN dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
     && rm -rf /etc/ssh/*key* \
-    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt \
     && ln -s /sbin/agetty /sbin/getty
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8 \
     && groupadd --gid 1100 rancher \

--- a/images/10-ubuntuconsole/Dockerfile
+++ b/images/10-ubuntuconsole/Dockerfile
@@ -3,8 +3,7 @@ FROM rancher/os-ubuntuconsole-base
 RUN apt-get update \
     && apt-get install -y --no-install-recommends iptables openssh-server rsync locales sudo vim less curl ca-certificates psmisc htop kmod iproute2 \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /etc/ssh/*key* \
-    && rm -fr /sbin/poweroff  /sbin/shutdown /sbin/reboot /sbin/halt /usr/sbin/poweroff  /usr/sbin/shutdown /usr/sbin/reboot /usr/sbin/halt
+    && rm -rf /etc/ssh/*key*
 RUN locale-gen en_US.UTF-8 \
     && addgroup --gid 1100 rancher \
     && addgroup --gid 1101 docker \


### PR DESCRIPTION
Depends on rancher/os#1409

These commands will be removed by `ros entrypoint` before power commands are symlinked to `ros`. It doesn't hurt to be removing these ahead of time, but it's no longer necessary.